### PR TITLE
Add fields to support a decrypted server side implementation of Apple Pay

### DIFF
--- a/apple_pay_card.go
+++ b/apple_pay_card.go
@@ -16,6 +16,10 @@ type ApplePayCard struct {
 	Last4                 string         `xml:"last-4"`
 	ExpirationMonth       string         `xml:"expiration-month"`
 	ExpirationYear        string         `xml:"expiration-year"`
+	ECI                   string         `xml:"eci-indicator"`
+	Cryptogram            string         `xml:"cryptogram"`
+	Number                string         `xml:"number"`
+	CardholderName        string         `xml:"cardholder-name"`
 	Expired               bool           `xml:"expired"`
 	Default               bool           `xml:"default"`
 	CustomerId            string         `xml:"customer-id"`

--- a/apple_pay_card.go
+++ b/apple_pay_card.go
@@ -7,25 +7,25 @@ import (
 
 type ApplePayCard struct {
 	XMLName               xml.Name       `xml:"apple-pay-card"`
-	Token                 string         `xml:"token"`
-	ImageURL              string         `xml:"image-url"`
-	CardType              string         `xml:"card-type"`
-	PaymentInstrumentName string         `xml:"payment-instrument-name"`
-	SourceDescription     string         `xml:"source-description"`
-	BIN                   string         `xml:"bin"`
-	Last4                 string         `xml:"last-4"`
-	ExpirationMonth       string         `xml:"expiration-month"`
-	ExpirationYear        string         `xml:"expiration-year"`
-	ECI                   string         `xml:"eci-indicator"`
-	Cryptogram            string         `xml:"cryptogram"`
-	Number                string         `xml:"number"`
-	CardholderName        string         `xml:"cardholder-name"`
-	Expired               bool           `xml:"expired"`
-	Default               bool           `xml:"default"`
-	CustomerId            string         `xml:"customer-id"`
-	CreatedAt             *time.Time     `xml:"created-at"`
-	UpdatedAt             *time.Time     `xml:"updated-at"`
-	Subscriptions         *Subscriptions `xml:"subscriptions"`
+	Token                 string         `xml:"token,omitempty"`
+	ImageURL              string         `xml:"image-url,omitempty"`
+	CardType              string         `xml:"card-type,omitempty"`
+	PaymentInstrumentName string         `xml:"payment-instrument-name,omitempty"`
+	SourceDescription     string         `xml:"source-description,omitempty"`
+	BIN                   string         `xml:"bin,omitempty"`
+	Last4                 string         `xml:"last-4,omitempty"`
+	ExpirationMonth       string         `xml:"expiration-month,omitempty"`
+	ExpirationYear        string         `xml:"expiration-year,omitempty"`
+	ECI                   string         `xml:"eci-indicator,omitempty"`
+	Cryptogram            string         `xml:"cryptogram,omitempty"`
+	Number                string         `xml:"number,omitempty"`
+	CardholderName        string         `xml:"cardholder-name,omitempty"`
+	Expired               bool           `xml:"expired,omitempty"`
+	Default               bool           `xml:"default,omitempty"`
+	CustomerId            string         `xml:"customer-id,omitempty"`
+	CreatedAt             *time.Time     `xml:"created-at,omitempty"`
+	UpdatedAt             *time.Time     `xml:"updated-at,omitempty"`
+	Subscriptions         *Subscriptions `xml:"subscriptions,omitempty"`
 }
 
 type ApplePayCards struct {

--- a/apple_pay_card_test.go
+++ b/apple_pay_card_test.go
@@ -1,0 +1,30 @@
+// +build unit
+
+package braintree
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestApplePayCard_MarshalXML(t *testing.T) {
+	card := ApplePayCard{
+		ExpirationMonth: "10",
+		ExpirationYear:  "22",
+		ECI:             "07",
+		Cryptogram:      "testCardCryptogram",
+		Number:          "4111111111111111",
+		CardholderName:  "Test User",
+	}
+
+	cardString, err := xml.Marshal(card)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	expected := `<apple-pay-card><expiration-month>10</expiration-month><expiration-year>22</expiration-year><eci-indicator>07</eci-indicator><cryptogram>testCardCryptogram</cryptogram><number>4111111111111111</number><cardholder-name>Test User</cardholder-name></android-pay-card>`
+
+	if cardString != expected {
+		t.Errorf("Marshalled xml got [%s], want [%s]", cardString, expected)
+	}
+}

--- a/apple_pay_card_test.go
+++ b/apple_pay_card_test.go
@@ -22,7 +22,7 @@ func TestApplePayCard_MarshalXML(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	expected := `<apple-pay-card><expiration-month>10</expiration-month><expiration-year>22</expiration-year><eci-indicator>07</eci-indicator><cryptogram>testCardCryptogram</cryptogram><number>4111111111111111</number><cardholder-name>Test User</cardholder-name></android-pay-card>`
+	expected := `<apple-pay-card><expiration-month>10</expiration-month><expiration-year>22</expiration-year><eci-indicator>07</eci-indicator><cryptogram>testCardCryptogram</cryptogram><number>4111111111111111</number><cardholder-name>Test User</cardholder-name></apple-pay-card>`
 
 	if cardString != expected {
 		t.Errorf("Marshalled xml got [%s], want [%s]", cardString, expected)

--- a/transaction.go
+++ b/transaction.go
@@ -113,6 +113,7 @@ type TransactionRequest struct {
 	MerchantAccountId   string                      `xml:"merchant-account-id,omitempty"`
 	PlanId              string                      `xml:"plan-id,omitempty"`
 	CreditCard          *CreditCard                 `xml:"credit-card,omitempty"`
+	ApplePayCard        *ApplePayCard               `xml:"apple-pay-card,omitempty"`
 	Customer            *CustomerRequest            `xml:"customer,omitempty"`
 	BillingAddress      *Address                    `xml:"billing,omitempty"`
 	ShippingAddress     *Address                    `xml:"shipping,omitempty"`


### PR DESCRIPTION
Documentation from Braintree on the decrypted server side implementation: https://developers.braintreepayments.com/guides/apple-pay/decrypted-server-side/php