### PR TITLE
Webhook: Payment method revoked by customer

### DIFF
--- a/webhook_notification.go
+++ b/webhook_notification.go
@@ -83,6 +83,7 @@ type webhookSubject struct {
 	Transaction               *Transaction               `xml:",omitempty"`
 	Dispute                   *Dispute                   `xml:"dispute,omitempty"`
 	AccountUpdaterDailyReport *AccountUpdaterDailyReport `xml:"account-updater-daily-report,omitempty"`
+	PaypalAccount             *PayPalAccount             `xml:"paypal-account"`
 
 	// Remaining Fields:
 	// partner_merchant

--- a/webhook_notification.go
+++ b/webhook_notification.go
@@ -83,7 +83,7 @@ type webhookSubject struct {
 	Transaction               *Transaction               `xml:",omitempty"`
 	Dispute                   *Dispute                   `xml:"dispute,omitempty"`
 	AccountUpdaterDailyReport *AccountUpdaterDailyReport `xml:"account-updater-daily-report,omitempty"`
-	PaypalAccount             *PayPalAccount             `xml:"paypal-account"`
+	PaypalAccount             *PayPalAccount             `xml:"paypal-account,omitempty"`
 
 	// Remaining Fields:
 	// partner_merchant

--- a/webhook_notification.go
+++ b/webhook_notification.go
@@ -31,6 +31,7 @@ const (
 	DisputeExpiredWebhook                    = "dispute_expired"
 	DisputeAcceptedWebhook                   = "dispute_accepted"
 	DisputeDisputedWebhook                   = "dispute_disputed"
+	PaymentMethodRevokedByCustomer           = "payment_method_revoked_by_customer"
 )
 
 type WebhookNotification struct {


### PR DESCRIPTION
This PR introduces the missing notification type: [the payment method revoked by customer](https://developers.braintreepayments.com/reference/general/webhooks/payment-method/ruby#notification-type-payment_method_revoked_by_customer).
This notification kind is already implemented in other Braintree official SDK, for instance, the [Java SDK](https://github.com/braintree/braintree_java/blob/92543816fbcb8ed69c46502c43b9f7552d34c7ef/src/main/java/com/braintreegateway/WebhookNotification.java#L40).