### PR TITLE
Allow multiple calls to Response::UnpackBody

### DIFF
--- a/braintree.go
+++ b/braintree.go
@@ -140,7 +140,7 @@ func (g *Braintree) executeVersion(ctx context.Context, method, path string, xml
 	btr := &Response{
 		Response: resp,
 	}
-	err = btr.unpackBody()
+	err = btr.UnpackBody()
 	if err != nil {
 		return nil, err
 	}

--- a/response.go
+++ b/response.go
@@ -1,6 +1,7 @@
 package braintree
 
 import (
+	"bytes"
 	"compress/gzip"
 	"encoding/xml"
 	"fmt"
@@ -186,7 +187,7 @@ func (r *Response) disputeEvidence() (*DisputeEvidence, error) {
 	return &b, nil
 }
 
-func (r *Response) unpackBody() error {
+func (r *Response) UnpackBody() error {
 	if len(r.Body) == 0 {
 		reader := r.Response.Body
 
@@ -203,6 +204,11 @@ func (r *Response) unpackBody() error {
 		if err != nil {
 			return err
 		}
+
+		// Ensure UnpackBody can be called again
+		r.Response.Header.Del("Content-Encoding")
+		r.Response.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
+
 		strippedBuf, err := xmlnil.StripNilElements(buf)
 		if err == nil {
 			r.Body = strippedBuf

--- a/response.go
+++ b/response.go
@@ -199,8 +199,6 @@ func (r *Response) unpackBody() error {
 			reader = gzipReader
 		}
 
-		defer func() { _ = r.Response.Body.Close() }()
-
 		buf, err := ioutil.ReadAll(reader)
 		if err != nil {
 			return err


### PR DESCRIPTION
Resetting the response body after we read it and removing the gzip header if present enable support for multiple calls to to `UnpackBody`. Also, I remove the deferred call to `Close()` since we already call `Close()` from `executeVersion`, and I export `UnpackBody` so that it can be called externally.