### PR TITLE
Add oauth gateway in braintree.go

### DIFF
--- a/braintree.go
+++ b/braintree.go
@@ -184,6 +184,10 @@ func (g *Braintree) WebhookTesting() *WebhookTestingGateway {
 	}
 }
 
+func (g * Braintree) Oauth() *OauthGateway  {
+	return &OauthGateway{g}
+}
+
 func (g *Braintree) PaymentMethod() *PaymentMethodGateway {
 	return &PaymentMethodGateway{g}
 }


### PR DESCRIPTION
Will be used to initialize oauth gateway from hail to call `CreateTokenFromCode`. The previous forget to define it here as a new gateway.