### PR TITLE
Add AcquirerReferenceNumber to Transaction

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -101,6 +101,7 @@ type Transaction struct {
 	Disputes                     []*Dispute                `xml:"disputes>dispute"`
 	AuthorizationExpiresAt       *time.Time                `xml:"authorization-expires-at"`
 	NetworkTransactionId         *string                   `xml:"network-transaction-id"`
+	AcquirerReferenceNumber      string                    `xml:"acquirer-reference-number"`
 }
 
 type TransactionRequest struct {


### PR DESCRIPTION
AcquirerReferenceNumber is an extremely useful field to have that is available in the xml